### PR TITLE
chore: Configure mypy and Pylance for cleaner type checking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v2
       - run: uv sync --dev
-      - run: uv run mypy src/
+      - run: uv run mypy
 
   test:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,22 @@ dev-dependencies = [
   "pre-commit>=4.2.0",
 ]
 
+[tool.mypy]
+strict = true
+python_version = "3.11"
+files = ["src/", "tests/"]
+show_error_codes = true
+show_column_numbers = true
+show_error_context = true
+incremental = true
+cache_dir = ".mypy_cache"
+
+
 [[tool.mypy.overrides]]
 module = ["debugpy.*"]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false

--- a/src/diffmage/cli/main.py
+++ b/src/diffmage/cli/main.py
@@ -21,7 +21,7 @@ def analyze(
         "summary", "--output", "-o", help="Output format: summary, json, table"
     ),
     debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug mode"),
-):
+) -> None:
     """Analyze git changes and extract structured information"""
     try:
         import debugpy
@@ -48,7 +48,7 @@ def analyze(
         raise typer.Exit(1)
 
 
-def display_summary_output(analysis: CommitAnalysis):
+def display_summary_output(analysis: CommitAnalysis) -> None:
     """Rich summary display of commit analysis"""
     # Header
     console.print(
@@ -71,7 +71,7 @@ def display_summary_output(analysis: CommitAnalysis):
             console.print(f"  ... and {len(analysis.files) - 10} more files")
 
 
-def display_table_output(analysis: CommitAnalysis):
+def display_table_output(analysis: CommitAnalysis) -> None:
     """Table format display of commit analysis"""
     table = Table(title="File Changes")
     table.add_column("File", style="cyan")

--- a/src/diffmage/git/diff_parser.py
+++ b/src/diffmage/git/diff_parser.py
@@ -17,7 +17,7 @@ class GitDiffParser:
 
         try:
             diff_text = self.repo.git.diff("--cached", "--no-color")
-        except git.exc.GitCommandError:
+        except git.GitCommandError:
             raise ValueError("Failed to get staged changes from git")
 
         if not diff_text.strip():

--- a/src/diffmage/utils/file_detector.py
+++ b/src/diffmage/utils/file_detector.py
@@ -5,7 +5,7 @@ from diffmage.core.models import FileType
 class FileDetector:
     """Detects file types based on path, extension, and content patterns"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     def detect_file_type(self, file_path: str) -> FileType:

--- a/tests/git/test_diff_parser.py
+++ b/tests/git/test_diff_parser.py
@@ -7,19 +7,19 @@ from unidiff.errors import UnidiffParseError
 
 
 @pytest.fixture
-def parser():
+def parser() -> GitDiffParser:
     """Create a GitDiffParser instance for testing."""
     return GitDiffParser()
 
 
 @pytest.fixture
-def mock_repo():
+def mock_repo() -> Mock:
     """Create a mock git repo for testing."""
     return Mock()
 
 
 @pytest.fixture
-def sample_file_diff():
+def sample_file_diff() -> FileDiff:
     """Create a sample FileDiff object for testing."""
     return FileDiff(
         old_path="src/main.py",
@@ -32,7 +32,7 @@ def sample_file_diff():
     )
 
 
-def test_convert_patched_file_added_file(parser):
+def test_convert_patched_file_added_file(parser: GitDiffParser) -> None:
     """Test converting a PatchedFile representing an added file"""
 
     mock_patched_file = Mock()
@@ -46,7 +46,7 @@ def test_convert_patched_file_added_file(parser):
     mock_patched_file.added = 10
     mock_patched_file.removed = 0
 
-    parser._detect_file_type = Mock(return_value=FileType.SOURCE_CODE)
+    setattr(parser, "_detect_file_type", Mock(return_value=FileType.SOURCE_CODE))
 
     file_diff = parser._convert_patched_file(mock_patched_file)
 
@@ -60,7 +60,7 @@ def test_convert_patched_file_added_file(parser):
     assert file_diff.lines_removed == 0
 
 
-def test_convert_patched_file_modified_file(parser):
+def test_convert_patched_file_modified_file(parser: GitDiffParser) -> None:
     """Test converting a PatchedFile representing a modified file"""
 
     mock_patched_file = Mock()
@@ -74,7 +74,7 @@ def test_convert_patched_file_modified_file(parser):
     mock_patched_file.added = 5
     mock_patched_file.removed = 3
 
-    parser._detect_file_type = Mock(return_value=FileType.SOURCE_CODE)
+    setattr(parser, "_detect_file_type", Mock(return_value=FileType.SOURCE_CODE))
 
     file_diff = parser._convert_patched_file(mock_patched_file)
 
@@ -88,7 +88,7 @@ def test_convert_patched_file_modified_file(parser):
     assert file_diff.lines_removed == 3
 
 
-def test_convert_patched_file_deleted_file(parser):
+def test_convert_patched_file_deleted_file(parser: GitDiffParser) -> None:
     """Test converting a PatchedFile representing a deleted file"""
 
     mock_patched_file = Mock()
@@ -102,7 +102,7 @@ def test_convert_patched_file_deleted_file(parser):
     mock_patched_file.added = 0
     mock_patched_file.removed = 8
 
-    parser._detect_file_type = Mock(return_value=FileType.SOURCE_CODE)
+    setattr(parser, "_detect_file_type", Mock(return_value=FileType.SOURCE_CODE))
 
     file_diff = parser._convert_patched_file(mock_patched_file)
 
@@ -116,7 +116,7 @@ def test_convert_patched_file_deleted_file(parser):
     assert file_diff.lines_removed == 8
 
 
-def test_convert_patched_file_renamed_file(parser):
+def test_convert_patched_file_renamed_file(parser: GitDiffParser) -> None:
     """Test converting a PatchedFile representing a renamed file"""
 
     mock_patched_file = Mock()
@@ -130,7 +130,7 @@ def test_convert_patched_file_renamed_file(parser):
     mock_patched_file.added = 2
     mock_patched_file.removed = 1
 
-    parser._detect_file_type = Mock(return_value=FileType.SOURCE_CODE)
+    setattr(parser, "_detect_file_type", Mock(return_value=FileType.SOURCE_CODE))
 
     file_diff = parser._convert_patched_file(mock_patched_file)
 
@@ -144,7 +144,7 @@ def test_convert_patched_file_renamed_file(parser):
     assert file_diff.lines_removed == 1
 
 
-def test_convert_patched_file_exception_handling(parser):
+def test_convert_patched_file_exception_handling(parser: GitDiffParser) -> None:
     """Test that exceptions in _convert_patched_file are handled gracefully"""
 
     mock_patched_file = Mock()
@@ -156,7 +156,9 @@ def test_convert_patched_file_exception_handling(parser):
     assert file_diff is None
 
 
-def test_parse_staged_changes_normal_operation(parser, mock_repo, sample_file_diff):
+def test_parse_staged_changes_normal_operation(
+    parser: GitDiffParser, mock_repo: Mock, sample_file_diff: FileDiff
+) -> None:
     """Test parse_staged_changes with normal operation"""
 
     mock_repo.git.diff.return_value = """diff --git a/src/main.py b/src/main.py
@@ -171,7 +173,7 @@ def test_parse_staged_changes_normal_operation(parser, mock_repo, sample_file_di
     mock_repo.active_branch.name = "main"
     parser.repo = mock_repo
 
-    parser._convert_patched_file = Mock(return_value=sample_file_diff)
+    setattr(parser, "_convert_patched_file", Mock(return_value=sample_file_diff))
 
     result = parser.parse_staged_changes()
 
@@ -185,11 +187,13 @@ def test_parse_staged_changes_normal_operation(parser, mock_repo, sample_file_di
     assert result.files[0].lines_removed == 0
 
 
-def test_parse_staged_changes_git_command_error(parser, mock_repo):
+def test_parse_staged_changes_git_command_error(
+    parser: GitDiffParser, mock_repo: Mock
+) -> None:
     """Test parse_staged_changes when git command fails"""
 
     mock_repo = Mock()
-    mock_repo.git.diff.side_effect = git.exc.GitCommandError(
+    mock_repo.git.diff.side_effect = git.GitCommandError(
         "git diff", "Git command failed"
     )
     parser.repo = mock_repo
@@ -198,7 +202,9 @@ def test_parse_staged_changes_git_command_error(parser, mock_repo):
         parser.parse_staged_changes()
 
 
-def test_parse_staged_changes_no_staged_changes(parser, mock_repo):
+def test_parse_staged_changes_no_staged_changes(
+    parser: GitDiffParser, mock_repo: Mock
+) -> None:
     """Test parse_staged_changes when no staged changes are found"""
 
     mock_repo.git.diff.return_value = ""
@@ -209,7 +215,9 @@ def test_parse_staged_changes_no_staged_changes(parser, mock_repo):
         parser.parse_staged_changes()
 
 
-def test_parse_staged_changes_diff_parsing_error(parser, mock_repo):
+def test_parse_staged_changes_diff_parsing_error(
+    parser: GitDiffParser, mock_repo: Mock
+) -> None:
     """Test parse_staged_changes when diff parsing fails"""
 
     mock_repo.git.diff.return_value = "some text that will cause parsing to fail"
@@ -226,7 +234,9 @@ def test_parse_staged_changes_diff_parsing_error(parser, mock_repo):
             parser.parse_staged_changes()
 
 
-def test_parse_staged_changes_empty_file_list(parser, mock_repo):
+def test_parse_staged_changes_empty_file_list(
+    parser: GitDiffParser, mock_repo: Mock
+) -> None:
     """Test parse_staged_changes when _convert_patched_file returns None for all files"""
 
     mock_repo.git.diff.return_value = """diff --git a/src/main.py b/src/main.py
@@ -240,7 +250,7 @@ def test_parse_staged_changes_empty_file_list(parser, mock_repo):
     mock_repo.active_branch.name = "main"
     parser.repo = mock_repo
 
-    parser._convert_patched_file = Mock(return_value=None)
+    setattr(parser, "_convert_patched_file", Mock(return_value=None))
 
     result = parser.parse_staged_changes()
 

--- a/tests/utils/test_file_detector.py
+++ b/tests/utils/test_file_detector.py
@@ -4,12 +4,12 @@ from diffmage.utils.file_detector import FileDetector
 
 
 @pytest.fixture
-def file_detector():
+def file_detector() -> FileDetector:
     """Create a FileDetector instance for testing."""
     return FileDetector()
 
 
-def test_detect_file_type_source_code(file_detector):
+def test_detect_file_type_source_code(file_detector: FileDetector) -> None:
     """Test detection of source code files"""
 
     # Python files
@@ -25,7 +25,7 @@ def test_detect_file_type_source_code(file_detector):
     assert file_detector.detect_file_type("component.tsx") == FileType.SOURCE_CODE
 
 
-def test_detect_file_type_test_files(file_detector):
+def test_detect_file_type_test_files(file_detector: FileDetector) -> None:
     """Test detection of test files"""
 
     # Test files in test directories
@@ -44,7 +44,7 @@ def test_detect_file_type_test_files(file_detector):
     )
 
 
-def test_detect_file_type_config_files(file_detector):
+def test_detect_file_type_config_files(file_detector: FileDetector) -> None:
     """Test detection of configuration files"""
 
     # YAML files
@@ -68,7 +68,7 @@ def test_detect_file_type_config_files(file_detector):
     assert file_detector.detect_file_type("docker-compose.yml") == FileType.CONFIG
 
 
-def test_detect_file_type_documentation(file_detector):
+def test_detect_file_type_documentation(file_detector: FileDetector) -> None:
     """Test detection of documentation files"""
 
     # Markdown files
@@ -84,7 +84,7 @@ def test_detect_file_type_documentation(file_detector):
     assert file_detector.detect_file_type("presentation.pptx") == FileType.DOCUMENTATION
 
 
-def test_detect_file_type_unknown(file_detector):
+def test_detect_file_type_unknown(file_detector: FileDetector) -> None:
     """Test detection of unknown file types"""
 
     # Files with unknown extensions
@@ -96,7 +96,7 @@ def test_detect_file_type_unknown(file_detector):
     assert file_detector.detect_file_type("Makefile") == FileType.UNKNOWN
 
 
-def test_detect_file_type_edge_cases(file_detector):
+def test_detect_file_type_edge_cases(file_detector: FileDetector) -> None:
     """Test edge cases in file type detection"""
 
     # File with "test" in name but not a test file

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "diffmage"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
- Add mypy overrides for tests and third-party libraries
- Configure Plyance diagnostic severity to reduce noise
- Fix type checking warnings across codebase