### PR TITLE
refactor(evaluation): Early Return EvaluationResult

### DIFF
--- a/src/diffmage/evaluation/commit_message_evaluator.py
+++ b/src/diffmage/evaluation/commit_message_evaluator.py
@@ -56,10 +56,22 @@ class CommitMessageEvaluator:
         """
 
         if not commit_message.strip():
-            raise ValueError("Commit message cannot be empty")
+            return EvaluationResult(
+                what_score=1.0,
+                why_score=1.0,
+                reasoning="Empty commit message provides no information",
+                confidence=1.0,
+                model_used=self.model_name,
+            )
 
         if not git_diff.strip():
-            raise ValueError("Git diff cannot be empty")
+            return EvaluationResult(
+                what_score=1.0,
+                why_score=1.0,
+                reasoning="No diff provided. Cannot assess commit content",
+                confidence=1.0,
+                model_used=self.model_name,
+            )
 
         try:
             evaluation_prompt = get_evaluation_prompt(commit_message, git_diff)

--- a/tests/evaluation/test_llm_evaluator.py
+++ b/tests/evaluation/test_llm_evaluator.py
@@ -59,15 +59,21 @@ class TestLLMEvaluator:
         """Test evaluation with empty commit message."""
         evaluator = CommitMessageEvaluator()
 
-        with pytest.raises(ValueError, match="Commit message cannot be empty"):
-            evaluator.evaluate_commit_message("", "some diff")
+        result = evaluator.evaluate_commit_message("", "some diff")
+        assert result.what_score == 1.0
+        assert result.why_score == 1.0
+        assert result.overall_score == 1.0
+        assert result.confidence == 1.0
 
     def test_evaluate_commit_message_empty_diff(self):
         """Test evaluation with empty git diff."""
         evaluator = CommitMessageEvaluator()
 
-        with pytest.raises(ValueError, match="Git diff cannot be empty"):
-            evaluator.evaluate_commit_message("some message", "")
+        result = evaluator.evaluate_commit_message("some message", "")
+        assert result.what_score == 1.0
+        assert result.why_score == 1.0
+        assert result.overall_score == 1.0
+        assert result.confidence == 1.0
 
     def test_evaluate_commit_message_llm_error(self):
         """Test evaluation when LLM call fails."""


### PR DESCRIPTION
When no diff or commit message is blank, early return EvaluationResult instead of raising ValueError, improving user experience and error handling.