### PR TITLE
fix(evaluation_report): change default export paths to temporary directory

### DIFF
--- a/src/diffmage/evaluation/evaluation_report.py
+++ b/src/diffmage/evaluation/evaluation_report.py
@@ -283,7 +283,7 @@ class EvaluationReport:
     def export_csv_report(
         self,
         results: list[tuple[EvaluationResult, str]],
-        filename: str = "evaluation_report.csv",
+        filename: str = ".tmp/evaluation_report.csv",
     ) -> str:
         """
         Export evaluation data to CSV for analysis
@@ -334,7 +334,7 @@ class EvaluationReport:
     def export_json_report(
         self,
         results: list[tuple[EvaluationResult, str]],
-        filename: str = "evaluation_report.json",
+        filename: str = ".tmp/evaluation_report.json",
     ) -> str:
         """Export evaluation data to JSON"""
 


### PR DESCRIPTION
Changed default CSV and JSON export filenames to use .tmp directory instead of current working directory to prevent persistent file writes during evaluation reporting.