### PR TITLE
fix(evaluation): adjust score thresholds for quality ratings

### DIFF
--- a/src/diffmage/evaluation/models.py
+++ b/src/diffmage/evaluation/models.py
@@ -25,19 +25,19 @@ class QualityRater:
         Returns one of:
         - Excellent (4.5-5.0)
         - Good (3.5-4.4)
-        - Average (2.6-3.5)
-        - Poor (1.6-2.5)
-        - Very Poor (0.0-1.5)
+        - Average (2.5-3.4)
+        - Poor (1.5-2.4)
+        - Very Poor (1.0-1.4)
         """
-        if score >= ScoreThresholds.EXCELLENT:
+        if score >= ScoreThresholds.EXCELLENT:  # 4.5-5.0
             return "Excellent"
-        elif score > ScoreThresholds.GOOD:
+        elif score >= ScoreThresholds.GOOD:  # 3.5-4.4
             return "Good"
-        elif score > ScoreThresholds.AVERAGE:
+        elif score >= ScoreThresholds.AVERAGE:  # 2.5-3.4
             return "Average"
-        elif score > ScoreThresholds.POOR:
+        elif score >= ScoreThresholds.POOR:  # 1.5-2.4
             return "Poor"
-        else:
+        else:  # 1.0-1.4
             return "Very Poor"
 
     @staticmethod

--- a/tests/evaluation/test_evaluation_report.py
+++ b/tests/evaluation/test_evaluation_report.py
@@ -381,8 +381,8 @@ class TestEvaluationReport:
 
         assert stats["quality_distribution"]["Excellent"] == 0
         assert stats["quality_distribution"]["Good"] == 1
-        assert stats["quality_distribution"]["Average"] == 0
-        assert stats["quality_distribution"]["Poor"] == 1
+        assert stats["quality_distribution"]["Average"] == 1
+        assert stats["quality_distribution"]["Poor"] == 0
 
     def test_model_usage_calculations(self, report):
         """Test model usage calculations"""


### PR DESCRIPTION
Update the score thresholds in QualityRater to ensure proper categorization of ratings. The previous implementation had overlapping or incorrect ranges that could lead to misclassification. This change ensures each rating category has a distinct and accurate score range.